### PR TITLE
예시용 rest client 제시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // TODO: REMOVE
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     //JWT

--- a/src/main/java/com/next/genshinflow/config/EnkaClientConfig.java
+++ b/src/main/java/com/next/genshinflow/config/EnkaClientConfig.java
@@ -1,0 +1,33 @@
+package com.next.genshinflow.config;
+
+import com.next.genshinflow.infrastructure.enka.EnkaClient;
+import com.next.genshinflow.infrastructure.enka.EnkaClientErrorHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class EnkaClientConfig {
+
+    @Value("${enka.host}")
+    private String host;
+
+    @Bean
+    HttpServiceProxyFactory enkaClientProxyFactory() {
+        RestClient restClient = RestClient.builder()
+            .baseUrl(host)
+            .defaultStatusHandler(new EnkaClientErrorHandler())
+            .build();
+        RestClientAdapter adapter = RestClientAdapter.create(restClient);
+        return HttpServiceProxyFactory.builderFor(adapter).build();
+    }
+
+    @Bean
+    EnkaClient enkaClient(HttpServiceProxyFactory enkaClientProxyFactory) {
+        return enkaClientProxyFactory.createClient(EnkaClient.class);
+    }
+
+}

--- a/src/main/java/com/next/genshinflow/infrastructure/enka/EnkaClient.java
+++ b/src/main/java/com/next/genshinflow/infrastructure/enka/EnkaClient.java
@@ -1,0 +1,19 @@
+package com.next.genshinflow.infrastructure.enka;
+
+import com.next.genshinflow.application.user.dto.UserInfoResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange(accept = MediaType.APPLICATION_JSON_VALUE, contentType = MediaType.APPLICATION_JSON_VALUE)
+public interface EnkaClient {
+
+    @GetExchange("/api/uid/{uid}")
+    ResponseEntity<UserInfoResponse> getUserInfo(
+        @PathVariable("uid") String uid,
+        @RequestParam long info
+    );
+}

--- a/src/main/java/com/next/genshinflow/infrastructure/enka/EnkaClientErrorHandler.java
+++ b/src/main/java/com/next/genshinflow/infrastructure/enka/EnkaClientErrorHandler.java
@@ -1,0 +1,14 @@
+package com.next.genshinflow.infrastructure.enka;
+
+import java.io.IOException;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+public class EnkaClientErrorHandler extends DefaultResponseErrorHandler {
+
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+        // TODO: handle error if needed
+        super.handleError(response);
+    }
+}

--- a/src/main/resources/properties/client.properties
+++ b/src/main/resources/properties/client.properties
@@ -1,0 +1,1 @@
+enka.host=https://enka.network


### PR DESCRIPTION
올려주신 코드에서 review 반영안된 부분이 있어서요.
사실 말로 하면 의미전달이 잘 되지 않을 것 같아 코드로 올립니다.

단순 예시 코드로 참고만 부탁드릴게요.

1. Spring boot 3.2 이후부터는 WebClient style 로 작성할 수 있는 RestClient 가 들어왔습니다. RestTemplate에 비교되는 WebClient 의 편의성 때문에 바로 blocking 하면서까지 사용되는 경우가 많아 생긴 feature 로 Spring-starter-web 에 기본적으로 포함되어있습니다. 그로인해불필요하게 매번 block 하는 형태를 보일 필요가 없으며, webflux dependency 를 필요로하지 않게 되었습니다. (또한, 그 이전버전에서도 webClient 포함만을 위해 webflux를 사용해야 한다면 다른 겹치는 dependency는 exclude 해주는 편이 권장됩니다)
2. `ApiService` 라는 식의 명명은 너무 범용적이라 생각합니다. 좀더 목적과 의도를 알기 쉬운 네이밍을 사용하는 것이 좋아보입니다. e.g.) UserProfileService, ProfileService, EnkaService 등등